### PR TITLE
Add keyboard shortcut for hiding all lines in wxt

### DIFF
--- a/src/wxterminal/wxt_gui.cpp
+++ b/src/wxterminal/wxt_gui.cpp
@@ -1121,6 +1121,13 @@ void wxtPanel::OnKeyDownChar( wxKeyEvent &event )
 			}
 #endif /* DISABLE_SPACE_RAISES_CONSOLE */
 
+ 		case 'c' :
+ 			int i;
+ 			for (i=1; i<=wxt_cur_plotno && i<wxt_max_key_boxes; i++) {
+ 				wxt_key_boxes[i].hidden = !wxt_key_boxes[i].hidden;
+ 			}
+ 			wxt_current_panel->wxt_cairo_refresh();
+ 			return;
 		case 'q' :
 		/* ctrl+q does not send 113 but 17 */
 		/* WARNING : may be the same for other combinations */

--- a/src/wxterminal/wxt_gui.cpp
+++ b/src/wxterminal/wxt_gui.cpp
@@ -1124,7 +1124,7 @@ void wxtPanel::OnKeyDownChar( wxKeyEvent &event )
  		case 'c' :
  			int i;
  			for (i=1; i<=wxt_cur_plotno && i<wxt_max_key_boxes; i++) {
- 				wxt_key_boxes[i].hidden = !wxt_key_boxes[i].hidden;
+ 				wxt_key_boxes[i].hidden = TRUE;
  			}
  			wxt_current_panel->wxt_cairo_refresh();
  			return;


### PR DESCRIPTION
When plotting many aspects of a dataset in a single graph, it is often convenient to be able to hide all lines and then only selectively enable those that are of interest. This makes 'c' a keyboard shortcut for doing this in wxterminal.

Here, we a case is added to wxtPanel::OnKeyDownChar for handling this. In the long term, a better solution might be to dispatch a command like "hide line 1" to the main gnuplot process, which then triggers a replot, but then there first has to be a way of targeting a command to a specific line.

Patch has been tested against the latest CVS version on Arch Linux x64.
